### PR TITLE
feat：local variable（本地变量）中的 name 节点内容不进行翻译

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -2717,27 +2717,30 @@ let MutationObserverConfig = {
   characterData: true
 };
 
-let observer = new MutationObserver(function (mutations) {
-  let treeWalker = document.createTreeWalker(
-  document.body,
-  NodeFilter.SHOW_ALL,
-  { 
-    acceptNode: function (node) {
-      if (node.nodeType === 3 || (node.hasAttribute && (node.hasAttribute('data-label') || node.hasAttribute('placeholder')))) {
-        return NodeFilter.FILTER_ACCEPT;
-      } else {
-        return NodeFilter.FILTER_SKIP;
-      }
-    } 
-  },
-  false
-  );
-  let dataMap = new Map();
-  allData.forEach(([key, val]) => {
+
+// 初始化时转换一次翻译数组格式，避免 MutationObserver 触发时重复转换
+const dataMap = new Map();
+allData.forEach(([key, val]) => {
   if (key && !dataMap.has(key)) {
     dataMap.set(key, val);
   }
-  });
+});
+
+let observer = new MutationObserver(function (mutations) {
+  let treeWalker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_ALL,
+    { 
+      acceptNode: function (node) {
+        if (node.nodeType === 3 || (node.hasAttribute && (node.hasAttribute('data-label') || node.hasAttribute('placeholder')))) {
+          return NodeFilter.FILTER_ACCEPT;
+        } else {
+          return NodeFilter.FILTER_SKIP;
+        }
+      } 
+    },
+    false
+  );
   let currentNode = treeWalker.currentNode;
   while (currentNode) {
   if (currentNode.nodeType === 3) {

--- a/js/content.js
+++ b/js/content.js
@@ -2734,11 +2734,17 @@ let observer = new MutationObserver(function (mutations) {
     NodeFilter.SHOW_ALL,
     { 
       acceptNode: function (node) {
+        // 跳过 local variable 设置面板中的的名称节点，避免 local variable 里面的名称被翻译
+        const nodeUnderVariableInput = node.classList && node.classList.value.includes('variable_name--root');
+        if (nodeUnderVariableInput) {
+          // 这个节点以下的子节点（包括该节点）全部过滤掉
+          return NodeFilter.FILTER_REJECT;
+        }
+
         const nodeIsTextNode = node.nodeType === DOM_NODE_TYPE.TEXT_NODE;
         if (nodeIsTextNode) return NodeFilter.FILTER_ACCEPT;
 
         if (typeof node.hasAttribute !== 'function') return NodeFilter.FILTER_SKIP;
-
         const nodeHasTargetTextAttribute = node.hasAttribute('data-label') || node.hasAttribute('placeholder');
         return nodeHasTargetTextAttribute
           ? NodeFilter.FILTER_ACCEPT

--- a/js/content.js
+++ b/js/content.js
@@ -2734,7 +2734,11 @@ let observer = new MutationObserver(function (mutations) {
     NodeFilter.SHOW_ALL,
     { 
       acceptNode: function (node) {
-        // 跳过 local variable 设置面板中的的名称节点，避免 local variable 里面的名称被翻译
+        /**
+         * [issue](https://github.com/Figma-Cool/figmaCN/issues/143)
+         * 
+         * 跳过 local variable 设置面板中的的名称节点，避免 local variable 里面的名称被翻译
+         */
         const nodeUnderVariableInput = node.classList && node.classList.value.includes('variable_name--root');
         if (nodeUnderVariableInput) {
           // 这个节点以下的子节点（包括该节点）全部过滤掉

--- a/js/content.js
+++ b/js/content.js
@@ -2708,7 +2708,6 @@ const allData = [
   [`Zoom`, `缩放`],
 ]
 
-
 let MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 let MutationObserverConfig = {
   childList: true,
@@ -2735,30 +2734,37 @@ let observer = new MutationObserver(function (mutations) {
     NodeFilter.SHOW_ALL,
     { 
       acceptNode: function (node) {
-        if (node.nodeType === DOM_NODE_TYPE.TEXT_NODE || (node.hasAttribute && (node.hasAttribute('data-label') || node.hasAttribute('placeholder')))) {
-          return NodeFilter.FILTER_ACCEPT;
-        } else {
-          return NodeFilter.FILTER_SKIP;
-        }
+        const nodeIsTextNode = node.nodeType === DOM_NODE_TYPE.TEXT_NODE;
+        if (nodeIsTextNode) return NodeFilter.FILTER_ACCEPT;
+
+        if (typeof node.hasAttribute !== 'function') return NodeFilter.FILTER_SKIP;
+
+        const nodeHasTargetTextAttribute = node.hasAttribute('data-label') || node.hasAttribute('placeholder');
+        return nodeHasTargetTextAttribute
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_SKIP;
       } 
     },
     false
   );
-  let currentNode = treeWalker.currentNode;
-  while (currentNode) {
-  if (currentNode.nodeType === DOM_NODE_TYPE.TEXT_NODE) {
-    let key1 = currentNode.textContent;
-    if (dataMap.has(key1)) currentNode.textContent = dataMap.get(key1);
-  } else {
-    let key2 = currentNode.getAttribute('data-label');
-    if (key2 && dataMap.has(key2)) currentNode.setAttribute('data-label', dataMap.get(key2));
-    let key3 = currentNode.getAttribute('placeholder') || '';
-    if (key3 = key3.trim()) {
-      if (dataMap.has(key3)) currentNode.setAttribute('placeholder', dataMap.get(key3));
-    }
-  }
 
-  currentNode = treeWalker.nextNode();
+  let currentNode = treeWalker.currentNode;
+
+  while (currentNode) {
+    if (currentNode.nodeType === DOM_NODE_TYPE.TEXT_NODE) {
+      let key1 = currentNode.textContent;
+      if (dataMap.has(key1)) currentNode.textContent = dataMap.get(key1);
+    } else {
+      let key2 = currentNode.getAttribute('data-label');
+      if (key2 && dataMap.has(key2)) currentNode.setAttribute('data-label', dataMap.get(key2));
+
+      let key3 = currentNode.getAttribute('placeholder') || '';
+      if (key3 = key3.trim()) {
+        if (dataMap.has(key3)) currentNode.setAttribute('placeholder', dataMap.get(key3));
+      }
+    }
+
+    currentNode = treeWalker.nextNode();
   }
 });
 

--- a/js/content.js
+++ b/js/content.js
@@ -2717,7 +2717,6 @@ let MutationObserverConfig = {
   characterData: true
 };
 
-
 // 初始化时转换一次翻译数组格式，避免 MutationObserver 触发时重复转换
 const dataMap = new Map();
 allData.forEach(([key, val]) => {
@@ -2726,13 +2725,17 @@ allData.forEach(([key, val]) => {
   }
 });
 
+const DOM_NODE_TYPE = {
+  TEXT_NODE: 3,
+}
+
 let observer = new MutationObserver(function (mutations) {
   let treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ALL,
     { 
       acceptNode: function (node) {
-        if (node.nodeType === 3 || (node.hasAttribute && (node.hasAttribute('data-label') || node.hasAttribute('placeholder')))) {
+        if (node.nodeType === DOM_NODE_TYPE.TEXT_NODE || (node.hasAttribute && (node.hasAttribute('data-label') || node.hasAttribute('placeholder')))) {
           return NodeFilter.FILTER_ACCEPT;
         } else {
           return NodeFilter.FILTER_SKIP;
@@ -2743,7 +2746,7 @@ let observer = new MutationObserver(function (mutations) {
   );
   let currentNode = treeWalker.currentNode;
   while (currentNode) {
-  if (currentNode.nodeType === 3) {
+  if (currentNode.nodeType === DOM_NODE_TYPE.TEXT_NODE) {
     let key1 = currentNode.textContent;
     if (dataMap.has(key1)) currentNode.textContent = dataMap.get(key1);
   } else {


### PR DESCRIPTION
在使用 local varable（本地变量）特性时往往会采用 kebab-case 书写变量名，这种编写方式会命中翻译规则。本次 PR 处理了遍历DOM的结果，如果通过 class 识别到节点可能是 本地变量 模块的内容，则跳过该节点及其下子节点。